### PR TITLE
Add configurable optimization bailouts for hooks

### DIFF
--- a/transformer/src/types.ts
+++ b/transformer/src/types.ts
@@ -1,6 +1,54 @@
 import * as ts from "typescript";
 import type { BlockAnalyzer } from "./analyzer";
 
+export interface DisabledOptimizationOptions {
+    hooks?: string[];
+    props?: string[];
+}
+
+export interface ResolvedDisabledOptimizationOptions {
+    hooks: Set<string>;
+    props: Set<string>;
+}
+
+export function resolveDisabledOptimizations(
+    options: DisabledOptimizationOptions | undefined,
+): ResolvedDisabledOptimizationOptions {
+    const hooks = new Set<string>();
+    const props = new Set<string>();
+
+    if (options?.hooks) {
+        for (const hook of options.hooks) {
+            const trimmed = hook.trim();
+            if (trimmed) {
+                hooks.add(trimmed);
+            }
+        }
+    }
+
+    if (options?.props) {
+        for (const prop of options.props) {
+            const normalized = prop.trim().toLowerCase();
+            if (normalized) {
+                props.add(normalized);
+            }
+        }
+    }
+
+    return { hooks, props };
+}
+
+export function isResolvedDisabledOptimizations(
+    value: DisabledOptimizationOptions | ResolvedDisabledOptimizationOptions | undefined,
+): value is ResolvedDisabledOptimizationOptions {
+    return (
+        value !== undefined &&
+        value !== null &&
+        value.hooks instanceof Set &&
+        value.props instanceof Set
+    );
+}
+
 /**
  * Core types for block analysis and transformation
  */
@@ -95,8 +143,12 @@ export interface OptimizationContext {
     skipTransformFunctions: Set<string>;
     /** Stack of current function context to track if we're inside a skip function */
     functionContextStack: string[];
+    /** Set of functions that should use the basic transformation pipeline due to disabled features */
+    forceBasicTransformFunctions: Set<string>;
     /** Map of tag names to Roblox instance names */
     tagToInstanceNameMap: Map<string, string>;
     /** Type-only imports required from the runtime */
     requiredTypeImports: Set<string>;
+    /** Resolved disabled optimization configuration */
+    disabledOptimizations: ResolvedDisabledOptimizationOptions;
 }


### PR DESCRIPTION
## Summary
- add a disabledOptimizations transformer option that resolves hook and prop exclusions
- propagate the configuration through the analyzer and transformer to force basic JSX handling when flagged
- extend integration tests to cover hook-based bailouts and allow passing options to the harness

## Testing
- `cd transformer && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68f88b0fd9d4832982aeecd49429117b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `disabledOptimizations` option to transformer configuration, enabling users to disable advanced optimizations for specific hooks, which will fall back to basic transforms.
  * Custom bailout properties are now configurable for JSX attribute analysis.

* **Refactor**
  * Refactored optimization context to support conditional basic transform paths based on disabled optimization settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->